### PR TITLE
Allow Typescript files for stimulus controllers too

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const railsPlugin = (options = { matcher: /.+\..+/ }) => ({
       const controllerNames = files
           .map((module) => module
             .replace("./", "")
-            .replace("_controller.js", "")
+            .replace(/_controller.[j|t]s$/, "")
             .replace(/\//g, "--")
             .replace(/_/g, '-')
           )


### PR DESCRIPTION
Small change to allow `.ts` files to be autoloaded correctly