### PR TITLE
Use fast-glob as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "esbuild": "*"
   },
   "dependencies": {
-    "glob": "^10.0.0"
+    "fast-glob": "^3.2.12"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { globSync } = require('glob')
+const fg = require('fast-glob')
 
 // This plugin adds support for globs like "./**/*" to import an entire directory
 // We can use this to import arbitrary files or Stimulus controllers and ActionCable channels
@@ -27,7 +27,7 @@ const railsPlugin = (options = { matcher: /.+\..+/ }) => ({
       // Get a list of all files in the directory
       // [ 'accounts_controller.js', ... ]
       let files = (
-        globSync(args.pluginData.path, {
+        fg.globSync(args.pluginData.path, {
           cwd: args.pluginData.resolveDir,
         })
       )

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const railsPlugin = (options = { matcher: /.+\..+/ }) => ({
       // Get a list of all files in the directory
       // [ 'accounts_controller.js', ... ]
       let files = (
-        fg.globSync(args.pluginData.path, {
+        fg.sync(args.pluginData.path, {
           cwd: args.pluginData.resolveDir,
         })
       )


### PR DESCRIPTION
Closes #18 (maybe?)

This is my shot-in-the-dark, untested attempt and swapping out the `glob` dependency for `fast-glob`. From what I can see from its readme, the API is pretty much identical (at least for `globSync`).