### PR TITLE
updates the build script command as set-script is now depricated

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require("esbuild").build({
 Use npm to add it as the build script (requires npm `>= 7.1`)
 
 ```sh
-npm set-script build "node esbuild.config.js"
+npm pkg set scripts.build="node esbuild.config.js"
 ```
 
 or add it manually  in `package.json`


### PR DESCRIPTION
It was raising the error `Unknown command: "set-script"` 
As per this [documentation](https://docs.npmjs.com/cli/v8/commands/npm-set-script?v=true) the `set-script` command has been depricated