### PR TITLE
Add `chokidar` to install step and fix `esbuild.config.mjs` file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This package is designed to be used with [jsbundling-rails](https://github.com/r
 Install with npm or yarn
 
 ```bash
-yarn add esbuild-rails chodikar
+yarn add esbuild-rails chokidar
 ```
 
 ```bash
-npm i esbuild-rails chodikar
+npm i esbuild-rails chokidar
 ```
 
 Copy [`examples/esbuild.config.mjs`](examples/esbuild.config.mjs) to your git repository.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This package is designed to be used with [jsbundling-rails](https://github.com/r
 Install with npm or yarn
 
 ```bash
-yarn add esbuild-rails
+yarn add esbuild-rails chodikar
 ```
 
 ```bash
-npm i esbuild-rails
+npm i esbuild-rails chodikar
 ```
 
 Copy [`examples/esbuild.config.mjs`](examples/esbuild.config.mjs) to your git repository.
@@ -23,7 +23,7 @@ Copy [`examples/esbuild.config.mjs`](examples/esbuild.config.mjs) to your git re
 Use npm to add it as the build script (requires npm `>= 7.1`)
 
 ```sh
-npm pkg set scripts.build="node esbuild.config.js"
+npm pkg set scripts.build="node esbuild.config.mjs"
 ```
 
 or add it manually  in `package.json`


### PR DESCRIPTION
While migrating an app to use esbuild-rails I noticed the following to issues. If you don't install `chokidar` yourself to your app it would fail to build:

```
❯ yarn build
yarn run v1.22.19
warning ../package.json: No license field
$ node esbuild.config.mjs
node:internal/modules/esm/resolve:838
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'chokidar' imported from 
[project]/esbuild.config.mjs
    at packageResolve (node:internal/modules/esm/resolve:838:9)
    at moduleResolve (node:internal/modules/esm/resolve:907:18)
    at defaultResolve (node:internal/modules/esm/resolve:1037:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:650:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:599:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:582:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:241:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:132:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

~~I'm almost wondering if the `esbuild-rails` package itself should depend on `chokidar`.~~ Edit: I guess we can just add an note to the README.

Additionally I also updated the esbuild config file extension in the README.