### PR TITLE
Add `watchDirs` `onLoad`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,18 @@ const railsPlugin = (options = { matcher: /.+\..+/ }) => ({
         })
       )
 
+      const watchedDirs = new Set();
+      watchedDirs.add(args.pluginData.resolveDir);
+
       // Filter to match the import
       files = files.sort().filter(path => options.matcher.test(path));
+      
+      // Add directories of matched files to watchedDirs
+      files.forEach(file => {
+        const dir = path.dirname(path.resolve(args.pluginData.resolveDir, file));
+        watchedDirs.add(dir);
+      });
+
       const controllerNames = files.map(convertFilenameToControllerName)
 
       const importerCode = `
@@ -56,7 +66,7 @@ const railsPlugin = (options = { matcher: /.+\..+/ }) => ({
         export default modules;
       `;
 
-      return { contents: importerCode, resolveDir: args.pluginData.resolveDir };
+      return { contents: importerCode, resolveDir: args.pluginData.resolveDir, watchDirs: Array.from(watchedDirs) };
     });
   },
 });


### PR DESCRIPTION
close #27

Builds a set of `directories` to watch, and then returns that set.

Allows us to add a new stimulus controller and rebuild without restarting the dev server.

Note; this does require [esbuild v0.10.0](https://github.com/evanw/esbuild/blob/v0.10.0/CHANGELOG.md#0100) or higher; which doesn't seem specified in the package.json.

Thanks for the consideration 🙏 